### PR TITLE
Fixed sending StartAPI request after server handshake

### DIFF
--- a/eclientsocket.go
+++ b/eclientsocket.go
@@ -105,6 +105,15 @@ func (s *serverHandshake) read(b *bufio.Reader) error {
 	return err
 }
 
+// StartAPI is equivalent of IB API EClientSocket.startAPI().
+type StartAPI struct {
+	Client int64
+}
+
+func (s *StartAPI) code() OutgoingMessageID           { return mStartAPI }
+func (s *StartAPI) version() int64                    { return 1 }
+func (s *StartAPI) write(b *bytes.Buffer) (err error) { return writeInt(b, s.Client) }
+
 // CancelScannerSubscription is equivalent of IB API EClientSocket.cancelScannerSubscription().
 type CancelScannerSubscription struct {
 	id int64

--- a/engine.go
+++ b/engine.go
@@ -142,12 +142,15 @@ func NewEngine(opt NewEngineOptions) (*Engine, error) {
 	go e.startTransmitter()
 	go e.startMainLoop()
 
+	// send the StartAPI request
+	e.Send(&StartAPI{Client: e.client})
+
 	return &e, nil
 }
 
 func (e *Engine) handshake() error {
-	// write client version and id
-	clientShake := &clientHandshake{clientVersion, e.client}
+	// write client version
+	clientShake := &clientHandshake{clientVersion}
 	e.output.Reset()
 	if err := clientShake.write(e.output); err != nil {
 		return err

--- a/types.go
+++ b/types.go
@@ -32,18 +32,8 @@ type MatchedReply interface {
 
 type clientHandshake struct {
 	version int64
-	id      int64
 }
 
 func (c *clientHandshake) write(b *bytes.Buffer) error {
-	if err := writeInt(b, c.version); err != nil {
-		return err
-	}
-	if err := writeInt(b, mStartAPI); err != nil {
-		return err
-	}
-	if err := writeInt(b, 1); err != nil {
-		return err
-	}
-	return writeInt(b, c.id)
+	return writeInt(b, c.version)
 }


### PR DESCRIPTION
The client handshake did not follow the Java reference implementation.
The StartAPI request was sent before reading the server handshake.