### PR TITLE
fix credentials for non-docker gateway

### DIFF
--- a/testserver/.gitignore
+++ b/testserver/.gitignore
@@ -1,1 +1,2 @@
+ibcontroller.ini
 tws

--- a/testserver/ibgwstart
+++ b/testserver/ibgwstart
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+${IB_LOGIN:=fdemo}
+${IB_PASSWORD:=demouser}
+sed s/{{IBLOGIN}}/$IB_LOGIN/g ibcontroller-2.12.0.ini | sed s/{{IBPASSWORD}}/$IB_PASSWORD/g > ibcontroller.ini
+
 rm -rf tws
 mkdir tws
 pushd tws
 jar -xf ../unixmacosx-943.2a.jar
 pushd IBJts
-java -cp ../../ibcontroller-2.12.0.jar:jts.jar:total.2013.jar -Xmx512M -XX:MaxPermSize=128M ibcontroller.IBGatewayController ../../ibcontroller-2.12.0.ini &
+java -cp ../../ibcontroller-2.12.0.jar:jts.jar:total.2013.jar -Xmx512M -XX:MaxPermSize=128M ibcontroller.IBGatewayController ../../ibcontroller.ini &
 popd
 popd


### PR DESCRIPTION
The latest refactoring (credentials via ENV) broke the non-docker tests.

(I also have another pull request in preparation to update IBcontroller and TWS to the newest versions.)