### PR TITLE
fix ComboLegs

### DIFF
--- a/eclientsocket.go
+++ b/eclientsocket.go
@@ -282,10 +282,6 @@ func (r *RequestMarketData) write(b *bytes.Buffer) error {
 				return err
 			}
 		}
-	} else {
-		if err := writeInt(b, int64(0)); err != nil {
-			return err
-		}
 	}
 	if r.Comp != nil {
 		if err := (writeMapSlice{

--- a/eclientsocket.go
+++ b/eclientsocket.go
@@ -269,6 +269,9 @@ func (r *RequestMarketData) write(b *bytes.Buffer) error {
 		return err
 	}
 	if r.Contract.SecurityType == bagSecType {
+		if err := writeInt(b, int64(len(r.ComboLegs))); err != nil {
+			return err
+		}
 		for _, cl := range r.ComboLegs {
 			if err := (writeMapSlice{
 				{fct: writeInt, val: cl.ContractID},
@@ -286,13 +289,19 @@ func (r *RequestMarketData) write(b *bytes.Buffer) error {
 	}
 	if r.Comp != nil {
 		if err := (writeMapSlice{
+			{fct: writeBool, val: true},
 			{fct: writeInt, val: r.Comp.ContractID},
 			{fct: writeFloat, val: r.Comp.Delta},
 			{fct: writeFloat, val: r.Comp.Price},
 		}).Dump(b); err != nil {
 			return err
 		}
+	} else {
+		if err := writeBool(b, false); err != nil {
+			return err
+		}
 	}
+
 	if err := writeString(b, r.GenericTickList); err != nil {
 		return err
 	}

--- a/eclientsocket.go
+++ b/eclientsocket.go
@@ -301,7 +301,6 @@ func (r *RequestMarketData) write(b *bytes.Buffer) error {
 			return err
 		}
 	}
-
 	if err := writeString(b, r.GenericTickList); err != nil {
 		return err
 	}


### PR DESCRIPTION
For RequestMarketData the ComboLeg structure was written uncorrectly.

Here is the C++ source code:
```
    // Send combo legs for BAG requests (srv v8 and above)
    if( Compare(contract.secType, "BAG") == 0)
    {
        const Contract::ComboLegList* const comboLegs = contract.comboLegs.get();
        const int comboLegsCount = comboLegs ? comboLegs->size() : 0;
        ENCODE_FIELD( comboLegsCount);
        if( comboLegsCount > 0) {
            for( int i = 0; i < comboLegsCount; ++i) {
                const ComboLeg* comboLeg = ((*comboLegs)[i]).get();
                assert( comboLeg);
                ENCODE_FIELD( comboLeg->conId);
                ENCODE_FIELD( comboLeg->ratio);
                ENCODE_FIELD( comboLeg->action);
                ENCODE_FIELD( comboLeg->exchange);
            }
        }
    }

    if( m_serverVersion >= MIN_SERVER_VER_UNDER_COMP) {
        if( contract.underComp) {
            const UnderComp& underComp = *contract.underComp;
            ENCODE_FIELD( true);
            ENCODE_FIELD( underComp.conId);
            ENCODE_FIELD( underComp.delta);
            ENCODE_FIELD( underComp.price);
        }
        else {
            ENCODE_FIELD( false);
        }
    }
```

Now I can get quotes for combos (at least with Snapshot: false).