### PR TITLE
Avoid the account code is required for this operation for FA accounts.

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -124,6 +124,8 @@ func (a *AbstractManager) startMainLoop(preLoop func() error, receive func(r Rep
 			if ok {
 				a.err = e
 				return
+			} else {
+				errors = nil
 			}
 		case r := <-a.rc:
 			if a.consume(r, receive) {

--- a/primary_account_manager.go
+++ b/primary_account_manager.go
@@ -34,12 +34,7 @@ func NewPrimaryAccountManager(e *Engine) (*PrimaryAccountManager, error) {
 }
 
 func (p *PrimaryAccountManager) preLoop() error {
-	req := &RequestAccountUpdates{}
-	req.Subscribe = true
 	p.eng.Subscribe(p.rc, p.id)
-	if err := p.eng.Send(req); err != nil {
-		return err
-	}
 
 	// To address if being run under an FA account, request our accounts
 	// (the 321 warning-level error will be ignored for non-FA accounts)


### PR DESCRIPTION
When using a FA account, the current master consistently fails to login, reporting

```
Error validating request:-'dd' : cause - The account code is required for this operation.
```

Looking at the latest client implementation from IB, it looks like the server now requires the account code for the `RequestAccountUpdates` request.

This PR removes the first `RequestAccountUpdates` request and folds the workflow into the `RequestManagedAccounts` request. That way the event loop automatically sends the  `RequestAccountUpdates` requests for all accounts.