### PR TITLE
Avoid infinite loop in the manager

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -124,6 +124,8 @@ func (a *AbstractManager) startMainLoop(preLoop func() error, receive func(r Rep
 			if ok {
 				a.err = e
 				return
+			} else {
+				errors = nil
 			}
 		case r := <-a.rc:
 			if a.consume(r, receive) {


### PR DESCRIPTION
In the implementation of the Manager, once the preLoop() function close the channel, the main loop will enter an infinite loop as a closed channel in Go never blocks.

This PR proposes to set the closed channel to nil to avoid the infinite loop.