### PR TITLE
Fixes defer block not executed in manager

### DIFF
--- a/realtime_data_manager.go
+++ b/realtime_data_manager.go
@@ -1,0 +1,59 @@
+package ib
+
+import "fmt"
+
+// RealTimeBarsManager .
+type RealTimeBarsManager struct {
+	AbstractManager
+	request RequestRealTimeBars
+	data    *RealtimeBars
+}
+
+// NewRealTimeBarsManager Create a new RealTimeBarsManager for the given data request.
+func NewRealTimeBarsManager(e *Engine, request RequestRealTimeBars) (*RealTimeBarsManager, error) {
+	am, err := NewAbstractManager(e)
+	if err != nil {
+		return nil, err
+	}
+
+	request.id = e.NextRequestID()
+	m := &RealTimeBarsManager{
+		AbstractManager: *am,
+		request:         request,
+	}
+
+	go m.startMainLoop(m.preLoop, m.receive, m.preDestroy)
+	return m, nil
+}
+
+func (m *RealTimeBarsManager) preLoop() error {
+	m.eng.Subscribe(m.rc, m.request.id)
+	return m.eng.Send(&m.request)
+}
+
+func (m *RealTimeBarsManager) receive(r Reply) (UpdateStatus, error) {
+	switch r.(type) {
+	case *ErrorMessage:
+		r := r.(*ErrorMessage)
+		if r.SeverityWarning() {
+			return UpdateFalse, nil
+		}
+		return UpdateFalse, r.Error()
+	case *RealtimeBars:
+		hd := r.(*RealtimeBars)
+		m.data = hd
+		return UpdateFinish, nil
+	}
+	return UpdateFalse, fmt.Errorf("Unexpected type %v", r)
+}
+
+func (m *RealTimeBarsManager) preDestroy() {
+	m.eng.Unsubscribe(m.rc, m.request.id)
+}
+
+// Items .
+func (m *RealTimeBarsManager) Data() *RealtimeBars {
+	m.rwm.RLock()
+	defer m.rwm.RUnlock()
+	return m.data
+}

--- a/realtime_data_manager_test.go
+++ b/realtime_data_manager_test.go
@@ -1,0 +1,41 @@
+package ib
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRealTimeBarsManager(t *testing.T) {
+	engine := NewTestEngine(t)
+
+	defer engine.ConditionalStop(t)
+
+	request := RequestRealTimeBars{
+		Contract: Contract{
+			Symbol:       "EUR",
+			SecurityType: "CASH",
+			Exchange:     "IDEALPRO",
+			Currency:     "USD",
+		},
+		WhatToShow: RealTimeAsk,
+		UseRTH:     true,
+	}
+
+	rtbm, err := NewRealTimeBarsManager(engine, request)
+	if err != nil {
+		t.Fatalf("error creating RealTimeBarsManager, %v", err)
+	}
+
+	defer rtbm.Close()
+
+	SinkManagerTest(t, rtbm, 15*time.Second, 1)
+
+	data := rtbm.Data()
+	if data.High == 0 {
+		t.Fatalf("Expected high is non-zero")
+	}
+
+	if b, ok := <-rtbm.Refresh(); ok {
+		t.Fatalf("Expected the refresh channel to be closed, but got %t", b)
+	}
+}


### PR DESCRIPTION
Since the errors channel has became nil already, reading from it
in the defer block will be stuck forever.

Use another channel for this purpose and set errors to nil after
the errors channel is closed immediately.