### PR TITLE
Support for delayed/frozen market data

### DIFF
--- a/eclientsocket.go
+++ b/eclientsocket.go
@@ -1340,6 +1340,13 @@ func (r *RequestGlobalCancel) code() OutgoingMessageID     { return mRequestGlob
 func (r *RequestGlobalCancel) version() int64              { return 1 }
 func (r *RequestGlobalCancel) write(b *bytes.Buffer) error { return nil }
 
+const (
+	MarketDataTypeLive          = 1
+	MarketDataTypeFrozen        = 2
+	MarketDataTypeDelayed       = 3
+	MarketDataTypeDelayedFrozen = 4
+)
+
 // RequestMarketDataType is equivalent of IB API EClientSocket.reqMarketDataType()
 type RequestMarketDataType struct {
 	MarketDataType int64

--- a/instrument_manager.go
+++ b/instrument_manager.go
@@ -45,18 +45,18 @@ func (i *InstrumentManager) receive(r Reply) (UpdateStatus, error) {
 	switch r.(type) {
 	case *ErrorMessage:
 		r := r.(*ErrorMessage)
-		if r.SeverityWarning() {
+		if r.SeverityWarning() || r.Code == 10167 /*displaying delayed market data*/ {
 			return UpdateFalse, nil
 		}
 		return UpdateFalse, r.Error()
 	case *TickPrice:
 		r := r.(*TickPrice)
 		switch r.Type {
-		case TickLast:
+		case TickLast, TickDelayedLast:
 			i.last = r.Price
-		case TickBid:
+		case TickBid, TickDelayedBid:
 			i.bid = r.Price
-		case TickAsk:
+		case TickAsk, TickDelayedAsk:
 			i.ask = r.Price
 		}
 	}

--- a/tick_type.go
+++ b/tick_type.go
@@ -67,4 +67,11 @@ const (
 	TickLastRTHTrade                   = 57
 	TickNotSet                         = 58
 	TickRegulatoryImbalance            = 61
+	TickNews                           = 62
+	TickShortTermVolume3Min            = 63
+	TickShortTermVolume5Min            = 64
+	TickShortTermVolume10Min           = 65
+	TickDelayedBid                     = 66
+	TickDelayedAsk                     = 67
+	TickDelayedLast                    = 68
 )


### PR DESCRIPTION
To request delayed market data:

	engine.Send(&ib.RequestMarketDataType{
		MarketDataType: ib.MarketDataTypeDelayed,
	})

Data returned by InstrumentManager will contain delayed data.