### PR TITLE
Fix reading contract SecIDList

### DIFF
--- a/ereader.go
+++ b/ereader.go
@@ -1143,13 +1143,18 @@ func (c *ContractData) read(b *bufio.Reader) (err error) {
 		return err
 	}
 	c.Contract.SecIDList = make([]TagValue, secIDListCount)
-	for _, si := range c.Contract.SecIDList {
-		if si.Tag, err = readString(b); err != nil {
+	for i := int64(0); i < secIDListCount; i++ {
+		tag, err := readString(b)
+		if err != nil {
 			return err
 		}
-		if si.Value, err = readString(b); err != nil {
+		c.Contract.SecIDList[i].Tag = tag
+
+		value, err := readString(b)
+		if err != nil {
 			return err
 		}
+		c.Contract.SecIDList[i].Value = value
 	}
 	return err
 }


### PR DESCRIPTION
`range` copies the values from the slice we are iterating over. We don't
want to change copied values. Instead we want to mutate the contract sec
ID list. See https://stackoverflow.com/questions/15945030/change-values-while-iterating-in-golang