### PR TITLE
prevent unnecessary CPU hog in infinite loop

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -123,11 +123,9 @@ func (a *AbstractManager) startMainLoop(preLoop func() error, receive func(r Rep
 		select {
 		case <-a.exit:
 			return
-		case e, ok := <-errors:
-			if ok {
-				a.err = e
-				return
-			}
+		case e := <-errors:
+			a.err = e
+			return
 		case r := <-a.rc:
 			if a.consume(r, receive) {
 				return


### PR DESCRIPTION
Using second return value of receive operator satisfies the select's case when `errors` channel is closed, making another for loop iteration unnecessarily.