### PR TITLE
Prevent data race

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -123,11 +123,9 @@ func (a *AbstractManager) startMainLoop(preLoop func() error, receive func(r Rep
 		select {
 		case <-a.exit:
 			return
-		case e, ok := <-errors:
-			if ok {
-				a.err = e
-				return
-			}
+		case e := <-errors:
+			a.err = e
+			return
 		case r := <-a.rc:
 			if a.consume(r, receive) {
 				return

--- a/manager.go
+++ b/manager.go
@@ -114,8 +114,6 @@ func (a *AbstractManager) startMainLoop(preLoop func() error, receive func(r Rep
 		if err != nil {
 			errors <- err
 		}
-		close(errors)
-		errors = nil
 		preLoopFinished <- true
 	}()
 


### PR DESCRIPTION
This is finally the correct pull request preventing this data race (using race detector - `go run -race ...`):

```
==================
WARNING: DATA RACE
Write at 0x00c0000ba0c8 by goroutine 16:
  github.com/gofinance/ib.(*AbstractManager).startMainLoop.func2()
      /home/kexik/go/pkg/mod/github.com/gofinance/ib@v0.0.0-20190131202149-a7abd0c5d772/manager.go:118 +0x7d

Previous read at 0x00c0000ba0c8 by goroutine 14:
  github.com/gofinance/ib.(*AbstractManager).startMainLoop()
      /home/kexik/go/pkg/mod/github.com/gofinance/ib@v0.0.0-20190131202149-a7abd0c5d772/manager.go:126 +0x2b9

Goroutine 16 (running) created at:
  github.com/gofinance/ib.(*AbstractManager).startMainLoop()
      /home/kexik/go/pkg/mod/github.com/gofinance/ib@v0.0.0-20190131202149-a7abd0c5d772/manager.go:112 +0x1cd

Goroutine 14 (running) created at:
  github.com/gofinance/ib.NewHistoricalDataManager()
      /home/kexik/go/pkg/mod/github.com/gofinance/ib@v0.0.0-20190131202149-a7abd0c5d772/historical_data_manager.go:25 +0x499
==================

```

Talking about startMainLoop in manager.go:
- Closing `errors` channel would cause CPU hog in the infinite for loop in startMainLoop (the case of the closed errors channel would be selected with ok=false every iteration).
- Preventing that CPU hog by setting `errors = nil` in that other gorountine causes this data race

The solution is actually leaving errors channel living, that is not a problem, it will be garbage-collected after the for loop is broken by any of the other `case` and the exit from startMainLoop.
