### PR TITLE
Fixing a potential memory leak problem

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -25,9 +25,13 @@ func getGatewayURL() string {
 }
 
 func (e *Engine) expect(t *testing.T, seconds int, ch chan Reply, expected []IncomingMessageID) (Reply, error) {
+	timeout := time.Duration(seconds) * time.Second
+	idleTimer := time.NewTimer(timeout)
+	defer idleTimer.Stop()
 	for {
+		idleTimer.Reset(timeout)
 		select {
-		case <-time.After(time.Duration(seconds) * time.Second):
+		case <-idleTimer.C:
 			return nil, errors.New("Timeout waiting")
 		case v := <-ch:
 			if v.code() == 0 {

--- a/manager.go
+++ b/manager.go
@@ -198,10 +198,13 @@ func (a *AbstractManager) Close() {
 // require the final result of a Manager (and have no interest in each update).
 // The Manager is guaranteed to be closed before it returns.
 func SinkManager(m Manager, timeout time.Duration, updateStop int) (updates int, err error) {
+	idleTimer := time.NewTimer(timeout)
+	defer idleTimer.Stop()
 	for {
 		sentClose := false
+		idleTimer.Reset(timeout)
 		select {
-		case <-time.After(timeout):
+		case <-idleTimer.C:
 			m.Close()
 			return updates, fmt.Errorf("SinkManager: no new update in %s", timeout)
 		case _, ok := <-m.Refresh():


### PR DESCRIPTION

The underlying Timer is not recovered by the garbage collector until the timer fires. It's better to use time.NewTimer instead and call its Stop method when the timer is no longer needed to avoid potential memory leak issues.

It's hard to run into a memory leak issue in 5 seconds, but it will potentially reduce memory pressure when there are many short-lived subscribers.
