### PR TITLE
DisplaySize in order must be 0 when received string is empty, not MaxInt64

### DIFF
--- a/ereader.go
+++ b/ereader.go
@@ -696,7 +696,7 @@ func (o *OpenOrder) read(b *bufio.Reader) (err error) {
 	if o.Order.StockRangeUpper, err = readFloat(b); err != nil {
 		return err
 	}
-	if o.Order.DisplaySize, err = readInt(b); err != nil {
+	if o.Order.DisplaySize, err = readIntOrDefaultIfEmpty(b, 0); err != nil {
 		return err
 	}
 	if o.Order.BlockOrder, err = readBool(b); err != nil {

--- a/wire.go
+++ b/wire.go
@@ -47,12 +47,16 @@ func readStringList(b *bufio.Reader, sep string) (r []string, err error) {
 }
 
 func readInt(b *bufio.Reader) (int64, error) {
+	return readIntOrDefaultIfEmpty(b,  math.MaxInt64)
+}
+
+func readIntOrDefaultIfEmpty(b *bufio.Reader, defaultIfEmpty int64) (int64, error) {
 	str, err := readString(b)
 	if err != nil {
 		return -1, err
 	}
 	if str == "" {
-		return math.MaxInt64, nil
+		return defaultIfEmpty, nil
 	}
 	i, err := strconv.ParseInt(str, 10, 64)
 	return i, err


### PR DESCRIPTION
The default value of DisplaySize must be zero, not MaxInt64, when reading Order data from TWS. Otherwise if you try to send PlaceOrder request with the same fields as the received order, except for the parameter to modify, you'll get `Unable to parse data. java.lang.NumberFormatException: For input string: "9223372036854775807"` error from TWS. It's because TWS can't parse DisplaySize value that is equal to MaxInt64. Actually, when you call NewOrder method, the default value of DisplaySize is zero, not MaxInt64. Why it should be different, when you read the order from TWS?